### PR TITLE
chore: Add dotenv for environment variable management

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -13,6 +13,7 @@ dist
 dist-ssr
 coverage
 *.local
+.env
 
 /cypress/videos/
 /cypress/screenshots/

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "dotenv": "^16.4.7",
         "pinia": "^2.2.6",
         "vue": "^3.5.13",
         "vue-router": "^4.4.5"
@@ -3740,6 +3741,18 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "dotenv": "^16.4.7",
     "pinia": "^2.2.6",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/client/src/env.d.ts
+++ b/client/src/env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/client/src/services/transactionService.ts
+++ b/client/src/services/transactionService.ts
@@ -1,7 +1,7 @@
 import { ref, computed } from 'vue'
 import type { Transaction, Category } from '../types/Transaction'
 
-const BASE_URL = 'http://localhost:8000'
+const BASE_URL = import.meta.env.VITE_API_URL
 
 export function useTransactions() {
   const transactions = ref<Transaction[]>([])


### PR DESCRIPTION
Now is necessary to create a `.env` file in the `client` root directory and add the following line to set the API base URL:

`VITE_API_URL=http://api-endpoint`
