### PR TITLE
refactor: remove unnecessary class `!w-full` in progress bar

### DIFF
--- a/client/src/components/AnalyticsItem.vue
+++ b/client/src/components/AnalyticsItem.vue
@@ -13,7 +13,7 @@
           backgroundColor: item.color,
           width: `${item.percentage}%`
         }"
-        class="h-full rounded-full !w-full"
+        class="h-full rounded-full"
       ></div>
     </div>
     <div>


### PR DESCRIPTION
The class `!w-full` was overriding the dynamically calculated width of the progress bar, removing it ensures that the width is correctly set based on the item's dynamic value.
