### PR TITLE
feat: add category filter to get_transactions endpoint and corresponding tests

### DIFF
--- a/server/src/api.py
+++ b/server/src/api.py
@@ -26,9 +26,10 @@ def to_month_year(month: Optional[str]) -> Optional[MonthYear]:
 def get_transactions(
     finance_service: FinanceService = Depends(finance_service),
     month: Optional[str] = YearMonthQuery,
+    category_id: Optional[str] = Query(None, description="Filter by category"),
 ) -> Sequence[Transaction]:
     month_filter = to_month_year(month)
-    transactions = finance_service.get_transactions(month=month_filter)
+    transactions = finance_service.get_transactions(month=month_filter, category_id=category_id)
     return transactions
 
 

--- a/server/src/services/finances.py
+++ b/server/src/services/finances.py
@@ -75,7 +75,9 @@ class FinanceService:
         self.session.refresh(transaction)
         return transaction
 
-    def get_transactions(self, month: Optional[MonthYear] = None) -> Sequence[Transaction]:
+    def get_transactions(
+        self, month: Optional[MonthYear] = None, category_id: Optional[str] = None
+    ) -> Sequence[Transaction]:
         statement = select(Transaction)
 
         # Filter by month if provided
@@ -84,6 +86,8 @@ class FinanceService:
                 func.extract("year", Transaction.date) == month.year,
                 func.extract("month", Transaction.date) == month.month,
             ).order_by(Transaction.date.desc())
+        if category_id:
+            statement = statement.where(Transaction.category_id == category_id)
 
         return self.session.exec(statement).all()
 


### PR DESCRIPTION
This PR adds the ability to filter transactions by category_id. Ex:
* `GET /transactions?category_id=3v2znBBbuK6aDTAkRdfsB6`: Filter by category ID
* `GET /transactions?category_id=3v2znBBbuK6aDTAkRdfsB6&month=2024-12`: Filter by category ID AND month