### PR TITLE
fix: format currency symbol for negative values using Intl.NumberFormat

### DIFF
--- a/client/src/components/AnalyticsChart.vue
+++ b/client/src/components/AnalyticsChart.vue
@@ -11,8 +11,6 @@
   import { useAccountStore } from '../stores/accountStore'
 
   const accountStore = useAccountStore()
-
-  const currencySymbol = accountStore.selectedCurrency?.symbol || ''
   
   interface Props {
     summary: AnalyticsSummary
@@ -49,7 +47,7 @@
           const percentage = formatPercentage(value, props.summary.total)
           return [
             `${context.label}:`,
-            `${currencySymbol + value} (${percentage})`
+            `${accountStore.formatCurrency(value)} (${percentage})`
           ]
         }
       }

--- a/client/src/components/AnalyticsItem.vue
+++ b/client/src/components/AnalyticsItem.vue
@@ -17,7 +17,7 @@
       ></div>
     </div>
     <div>
-      <span class="text-xs flex">{{ currencySymbol }}{{ item.total }}</span>
+      <span class="text-xs flex">{{ accountStore.formatCurrency(item.total) }}</span>
     </div>
   </div>
 </template>
@@ -27,8 +27,6 @@ import type { AnalyticsItem } from '../types/Analytics'
 import { useAccountStore } from '../stores/accountStore'
 
 const accountStore = useAccountStore()
-
-const currencySymbol = accountStore.selectedCurrency?.symbol || ''
 
 const props = defineProps<{
   item: AnalyticsItem

--- a/client/src/components/AnalyticsSummary.vue
+++ b/client/src/components/AnalyticsSummary.vue
@@ -27,7 +27,7 @@
 
       <div class="flex justify-between text-xs font-medium border-t mt-4 pt-3">
         <span>Total</span>
-        <span>{{ currencySymbol }}{{ store.analyticsSummary.total }}</span>
+        <span>{{ accountStore.formatCurrency(store.analyticsSummary.total) }}</span>
       </div>
       <AnalyticsChart 
         v-if="isChartVisible"
@@ -52,9 +52,6 @@ const isChartVisible = ref(false)
 const toggleChart = () => {
   isChartVisible.value = !isChartVisible.value
 }
-
-const currencySymbol = accountStore.selectedCurrency?.symbol || ''
-
 
 onMounted(async () => {
   await store.fetchCategories()

--- a/client/src/components/TransactionItem.vue
+++ b/client/src/components/TransactionItem.vue
@@ -26,7 +26,7 @@
       </div>
       
       <div class="ml-auto text-xs font-medium">
-        {{ currencySymbol }}{{ transaction.amount }}
+        {{ accountStore.formatCurrency(transaction.amount) }}
       </div>
     </div>
   </div>
@@ -38,8 +38,6 @@ import type { Transaction, Category } from '../types/Transaction'
 import { useAccountStore } from '../stores/accountStore'
 
 const accountStore = useAccountStore()
-
-const currencySymbol = accountStore.selectedCurrency?.symbol || ''
 
 const props = defineProps<{
   transaction: Transaction

--- a/client/src/stores/accountStore.ts
+++ b/client/src/stores/accountStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 
 const BASE_URL = import.meta.env.VITE_API_URL
 
@@ -20,6 +20,17 @@ export const useAccountStore = defineStore('account', () => {
   const accounts = ref<Account[]>([])
   const selectedCurrency = ref<Currency | null>(null)
 
+  const formatter = computed(() => {
+    return new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency: selectedCurrency.value?.code || 'USD',
+    })
+  })
+
+  const formatCurrency = (amount: number) => {
+    return formatter.value.format(amount)
+  }
+
   const fetchAccounts = async () => {
     try {
       const response = await fetch(`${BASE_URL}/accounts`)
@@ -35,5 +46,6 @@ export const useAccountStore = defineStore('account', () => {
   return {
     selectedCurrency,
     fetchAccounts,
+    formatCurrency,
   }
 })


### PR DESCRIPTION
This PR fixes an issue where the currency symbol would incorrectly precede the negative sign for transactions with negative amounts, the issue is resolved by utilizing Intl.NumberFormat to format values consistently according to locale standards.

<img width="512" alt="image" src="https://github.com/user-attachments/assets/f18d4dbb-cbe5-46bf-ab66-84d4b8caa3e1" />
