### PR TITLE
feat: Add service dependency injection with live/demo modes

### DIFF
--- a/client/src/components/AnalyticsSummary.vue
+++ b/client/src/components/AnalyticsSummary.vue
@@ -11,28 +11,19 @@
     <div v-else-if="store.error" class="error">{{ store.error }}</div>
     <div v-else-if="store.analyticsSummary" class="bg-white flex flex-col px-7 pb-8 pt-4 gap-2 rounded-[0.3rem]">
       <div class="flex justify-end mb-4">
-        <button
-          @click="toggleChart"
-          class="hover:opacity-70 transition-opacity"
-        >
-        <ChartIcon class="w-5 h-5" />
-      </button>
+        <button @click="toggleChart" class="hover:opacity-70 transition-opacity">
+          <ChartIcon class="w-5 h-5" />
+        </button>
 
       </div>
-      <AnalyticsItem
-        v-for="item in store.analyticsSummary.items"
-        :key="item.categoryId || 'uncategorized'"
-        :item="item"
-      />
+      <AnalyticsItem v-for="item in store.analyticsSummary.items" :key="item.categoryId || 'uncategorized'"
+        :item="item" />
 
       <div class="flex justify-between text-xs font-medium border-t mt-4 pt-3">
         <span>Total</span>
         <span>{{ accountStore.formatCurrency(store.analyticsSummary.total) }}</span>
       </div>
-      <AnalyticsChart
-        v-if="isChartVisible"
-        :summary="store.analyticsSummary"
-      />
+      <AnalyticsChart v-if="isChartVisible" :summary="store.analyticsSummary" />
     </div>
   </div>
 </template>
@@ -41,12 +32,14 @@
 import { ref, onMounted } from 'vue'
 import { useTransactionStore } from '../stores/transactionStore'
 import { useAccountStore } from '../stores/accountStore'
+import { TransactionService } from '../services/transactionService'
 import AnalyticsItem from './AnalyticsItem.vue'
 import AnalyticsChart from './AnalyticsChart.vue'
 import ChartIcon from './icons/ChartIcon.vue'
 
 const store = useTransactionStore()
 const accountStore = useAccountStore()
+const transactionService = new TransactionService()
 const isChartVisible = ref(true)
 
 const toggleChart = () => {
@@ -54,6 +47,6 @@ const toggleChart = () => {
 }
 
 onMounted(async () => {
-  await store.fetchCategories()
+  await store.fetchCategories(transactionService)
 })
 </script>

--- a/client/src/components/TransactionList.vue
+++ b/client/src/components/TransactionList.vue
@@ -2,57 +2,44 @@
   <div class="w-[80%]">
     <div class="mb-6 flex items-center gap-4">
       <div class="flex items-center gap-2">
-        <input
-          type="checkbox"
-          :checked="store.showAllTransactions"
-          @change="handleViewModeChange"
-          id="viewMode"
-          class="form-checkbox h-4 w-4"
-        />
+        <input type="checkbox" :checked="store.showAllTransactions" @change="handleViewModeChange" id="viewMode"
+          class="form-checkbox h-4 w-4" />
         <label for="viewMode" class="text-sm text-gray-700">Show all transactions</label>
       </div>
 
-      <input
-        v-if="!store.showAllTransactions"
-        type="month"
-        v-model="currentMonth"
-        @change="handleMonthChange"
-        class="px-4 py-2 border rounded-md"
-      />
+      <input v-if="!store.showAllTransactions" type="month" v-model="currentMonth" @change="handleMonthChange"
+        class="px-4 py-2 border rounded-md" />
     </div>
 
     <div v-if="store.isLoading" class="loading">Loading...</div>
     <div v-else-if="store.error" class="error">{{ store.error }}</div>
-    
+
     <template v-else>
       <div v-for="(transactions, date) in store.groupedTransactions" :key="date">
-        <TransactionDateGroup 
-          :date="date"
-          :transactions="transactions"
-        />
+        <TransactionDateGroup :date="date" :transactions="transactions" />
       </div>
     </template>
   </div>
 </template>
-  
+
 <script setup lang="ts">
 import { onMounted, watch } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
+import { useRoute } from 'vue-router'
 import TransactionDateGroup from './TransactionDateGroup.vue'
 import { useTransactionStore } from '../stores/transactionStore'
-import { TransactionUrlService } from '../services/transactionUrlService'
+import { useTransactionManager } from '../composables/useTransactionManager'
 
 const store = useTransactionStore()
-const router = useRouter()
 const route = useRoute()
+const {
+  currentMonth,
+  initialize,
+  handleMonthChange,
+  handleViewModeChange,
+  handleUrlChange
+} = useTransactionManager()
 
-const urlService = new TransactionUrlService(router, route)
-const currentMonth = urlService.getCurrentMonth()
+watch(() => route.query, (newQuery) => handleUrlChange(newQuery as Record<string, string>))
 
-const handleMonthChange = () => urlService.handleMonthChange(currentMonth.value)
-const handleViewModeChange = () => urlService.handleViewModeChange()
-
-watch(() => route.query, (newQuery) => urlService.handleUrlChange(newQuery as Record<string, string>))
-
-onMounted(() => urlService.initialize())
+onMounted(() => initialize())
 </script>

--- a/client/src/composables/useTransactionManager.ts
+++ b/client/src/composables/useTransactionManager.ts
@@ -1,0 +1,67 @@
+import { ref } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { TransactionService } from '../services/transactionService'
+import { UrlService } from '../services/urlService'
+import { useTransactionStore } from '../stores/transactionStore'
+
+export function useTransactionManager() {
+  const router = useRouter()
+  const route = useRoute()
+  const store = useTransactionStore()
+  const transactionService = new TransactionService()
+  const urlService = new UrlService(router, route)
+
+  const currentMonth = ref(new Date().toISOString().slice(0, 7))
+
+  const initialize = async () => {
+    const { month, showAll } = urlService.getInitialState()
+
+    if (month) {
+      currentMonth.value = month
+    }
+
+    store.setShowAllTransactions(showAll)
+
+    await Promise.all([
+      store.fetchCategories(transactionService),
+      store.refreshData(transactionService, currentMonth.value),
+    ])
+
+    urlService.updateURL(store.showAllTransactions, currentMonth.value)
+  }
+
+  const handleMonthChange = async (month: string) => {
+    currentMonth.value = month
+    await store.refreshData(transactionService, month)
+    urlService.updateURL(store.showAllTransactions, month)
+  }
+
+  const handleViewModeChange = async () => {
+    store.setShowAllTransactions(!store.showAllTransactions)
+    await store.refreshData(transactionService, currentMonth.value)
+    urlService.updateURL(store.showAllTransactions, currentMonth.value)
+  }
+
+  const handleUrlChange = async (query: Record<string, string>) => {
+    const newMonth = query.month
+    const showAll = query.showAll === 'true'
+
+    if (showAll !== store.showAllTransactions) {
+      store.setShowAllTransactions(showAll)
+    }
+
+    if (newMonth && newMonth !== currentMonth.value) {
+      currentMonth.value = newMonth
+    }
+
+    await store.refreshData(transactionService, newMonth)
+  }
+
+  return {
+    currentMonth,
+    initialize,
+    handleMonthChange,
+    handleViewModeChange,
+    handleUrlChange,
+  }
+}

--- a/client/src/composables/useTransactionManager.ts
+++ b/client/src/composables/useTransactionManager.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import { TransactionService } from '../services/transactionService'
+import { inject } from 'vue'
+import { TransactionServiceKey } from '../plugins/serviceProvider'
 import { UrlService } from '../services/urlService'
 import { useTransactionStore } from '../stores/transactionStore'
 
@@ -8,9 +9,14 @@ export function useTransactionManager() {
   const router = useRouter()
   const route = useRoute()
   const store = useTransactionStore()
-  const transactionService = new TransactionService()
-  const urlService = new UrlService(router, route)
 
+  // Inject the transaction service using the key
+  const transactionService = inject(TransactionServiceKey)
+  if (!transactionService) {
+    throw new Error('TransactionService not provided')
+  }
+
+  const urlService = new UrlService(router, route)
   const currentMonth = ref(new Date().toISOString().slice(0, 7))
 
   const initialize = async () => {
@@ -57,11 +63,16 @@ export function useTransactionManager() {
     await store.refreshData(transactionService, newMonth)
   }
 
+  const refreshData = async () => {
+    await store.refreshData(transactionService, currentMonth.value)
+  }
+
   return {
     currentMonth,
     initialize,
     handleMonthChange,
     handleViewModeChange,
     handleUrlChange,
+    refreshData,
   }
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -5,12 +5,16 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 
 import App from './App.vue'
+import { createServiceProvider } from './plugins/serviceProvider'
 import router from './router'
 
+const isDemoMode = import.meta.env.VITE_DEMO_MODE === 'true'
 const app = createApp(App)
 
 app.use(createPinia())
 app.use(router)
 app.use(PrimeVue)
+
+app.use(createServiceProvider(isDemoMode))
 
 app.mount('#app')

--- a/client/src/plugins/serviceProvider.ts
+++ b/client/src/plugins/serviceProvider.ts
@@ -1,0 +1,19 @@
+import { InjectionKey } from 'vue'
+import { TransactionServiceInterface } from '../types/TransactionServiceInterface'
+import { LiveTransactionService } from '../services/LiveTransactionService'
+import { DemoTransactionService } from '../services/DemoTransactionService'
+
+export const TransactionServiceKey: InjectionKey<TransactionServiceInterface> =
+  Symbol('TransactionService')
+
+export const createServiceProvider = (isDemoMode = false) => {
+  const transactionService = isDemoMode
+    ? new DemoTransactionService()
+    : new LiveTransactionService()
+
+  return {
+    install(app: App) {
+      app.provide(TransactionServiceKey, transactionService)
+    },
+  }
+}

--- a/client/src/services/DemoTransactionService.ts
+++ b/client/src/services/DemoTransactionService.ts
@@ -1,0 +1,304 @@
+import { TransactionServiceInterface } from '../types/TransactionServiceInterface'
+import type { Transaction, Category, AnalyticsResponse } from '../types/Transaction'
+
+export class DemoTransactionService implements TransactionServiceInterface {
+  private readonly demoCategories: Category[] = [
+    {
+      icon: 'rectangle-stack',
+      title: 'General',
+      id: 'k2Bnio4r4rumjEtf7KAnRP',
+      color: '#808080',
+    },
+    {
+      icon: 'truck',
+      title: 'Transport',
+      id: 'nmvY3NerXM3t8n3GCD3S9e',
+      color: '#4B77BE',
+    },
+    {
+      icon: 'home',
+      title: 'Housing',
+      id: '8dbxskvYv3k672TJCjniQx',
+      color: '#8B4513',
+    },
+    {
+      icon: 'shopping-cart',
+      title: 'Groceries',
+      id: 'anXz4uDvzF29jzUqX7cyPq',
+      color: '#FF9800',
+    },
+    {
+      icon: 'shopping-bag',
+      title: 'Shopping',
+      id: '3v2znBBbuK6aDTAkRdfsB6',
+      color: '#FF69B4',
+    },
+    {
+      icon: 'credit-card',
+      title: 'Bills',
+      id: 'TETAxd9u4he5dCWXZbBpRh',
+      color: '#D32F2F',
+    },
+    {
+      icon: 'film',
+      title: 'Entertainment',
+      id: 'TZuwyBFHemk95U6avZfvEf',
+      color: '#9B59B6',
+    },
+    {
+      icon: 'cake',
+      title: 'Eating Out',
+      id: 'TdTY9ahjNKanyAvyUCmUth',
+      color: '#F1C40F',
+    },
+    {
+      icon: 'gift',
+      title: 'Charity',
+      id: 'AXLpno5SHNDB2WXvQSdzCZ',
+      color: '#87CEEB',
+    },
+    {
+      icon: 'heart',
+      title: 'Personal Care',
+      id: 'nK9LfGwKsFpv87XY8FYLY2',
+      color: '#1ABC9C',
+    },
+    {
+      icon: 'briefcase',
+      title: 'Business',
+      id: '8GshVk2jfcs4BKnLTVzx2w',
+      color: '#34495E',
+    },
+    {
+      icon: 'academic-cap',
+      title: 'Education',
+      id: 'Q3enGA7mRz3zGE59edkhBB',
+      color: '#3498DB',
+    },
+    {
+      icon: 'chart-bar',
+      title: 'Investments',
+      id: 'YdkFskyaobeDR4dVmFqUv9',
+      color: '#27AE60',
+    },
+    {
+      icon: 'calendar',
+      title: 'Holidays',
+      id: 'Liwwdaqt7fPJ6LKFACjpiX',
+      color: '#00BCD4',
+    },
+    {
+      icon: 'currency-pound',
+      title: 'Cash',
+      id: 'RDrzJ8BzASa6yNgecSPSfF',
+      color: '#16A085',
+    },
+    {
+      icon: 'currency-dollar',
+      title: 'Income',
+      id: 'jHC68t25b7qtqkUQq4Ny3C',
+      color: '#16A085',
+    },
+  ]
+
+  private readonly demoTransactions: Transaction[] = [
+    {
+      date: '2024-12-16T00:00:00',
+      description: 'TESCO EXPRESS OXFORD ST LONDON',
+      notes: null,
+      merchant_id: null,
+      exclude_from_analytics: false,
+      id: 'MzeQTsFVgDLigSZseYD3kE',
+      amount: '55.73',
+      category_id: 'anXz4uDvzF29jzUqX7cyPq',
+      account_id: 'amex',
+    },
+    {
+      date: '2024-12-16T00:00:00',
+      description: 'SAINSBURY LOCAL BRISTOL',
+      notes: null,
+      merchant_id: null,
+      exclude_from_analytics: false,
+      id: 'NkACEGSFrNcYQXcHWBxcTS',
+      amount: '34.04',
+      category_id: 'anXz4uDvzF29jzUqX7cyPq',
+      account_id: 'amex',
+    },
+    {
+      date: '2024-12-16T00:00:00',
+      description: 'HOLIDAY INN LONDON',
+      notes: null,
+      merchant_id: null,
+      exclude_from_analytics: false,
+      id: 'd5pcA4xvqNjsjtS8PH5rE8',
+      amount: '2924.53',
+      category_id: 'Liwwdaqt7fPJ6LKFACjpiX',
+      account_id: 'amex',
+    },
+    {
+      date: '2024-12-16T00:00:00',
+      description: 'H&M OXFORD ST',
+      notes: null,
+      merchant_id: null,
+      exclude_from_analytics: false,
+      id: 'KjpcB5xvqNjsjtS8PH5rE9',
+      amount: '1234.64',
+      category_id: '3v2znBBbuK6aDTAkRdfsB6',
+      account_id: 'amex',
+    },
+    {
+      date: '2024-12-16T00:00:00',
+      description: 'UBER TRIP LONDON',
+      notes: null,
+      merchant_id: null,
+      exclude_from_analytics: false,
+      id: 'LmpcC6xvqNjsjtS8PH5rF0',
+      amount: '596.45',
+      category_id: 'nmvY3NerXM3t8n3GCD3S9e',
+      account_id: 'amex',
+    },
+    {
+      date: '2024-12-14T00:00:00',
+      description: 'VUE CINEMA BRISTOL',
+      notes: null,
+      merchant_id: null,
+      exclude_from_analytics: false,
+      id: 'PqpcD7xvqNjsjtS8PH5rF1',
+      amount: '518.25',
+      category_id: 'TZuwyBFHemk95U6avZfvEf',
+      account_id: 'amex',
+    },
+    {
+      date: '2024-12-14T00:00:00',
+      description: "NANDO'S BRISTOL",
+      notes: null,
+      merchant_id: null,
+      exclude_from_analytics: false,
+      id: 'QrpcE8xvqNjsjtS8PH5rF2',
+      amount: '384.38',
+      category_id: 'TdTY9ahjNKanyAvyUCmUth',
+      account_id: 'amex',
+    },
+    {
+      date: '2024-12-12T00:00:00',
+      description: 'UDEMY COURSE',
+      notes: null,
+      merchant_id: null,
+      exclude_from_analytics: false,
+      id: 'RspcF9xvqNjsjtS8PH5rF3',
+      amount: '131.50',
+      category_id: 'Q3enGA7mRz3zGE59edkhBB',
+      account_id: 'amex',
+    },
+    {
+      date: '2024-12-14T00:00:00',
+      description: 'BOOTS PHARMACY',
+      notes: null,
+      merchant_id: null,
+      exclude_from_analytics: false,
+      id: 'StpcG0xvqNjsjtS8PH5rF4',
+      amount: '104.43',
+      category_id: 'nK9LfGwKsFpv87XY8FYLY2',
+      account_id: 'amex',
+    },
+    {
+      date: '2024-12-14T00:00:00',
+      description: 'MAINTENANCE FEE',
+      notes: null,
+      merchant_id: null,
+      exclude_from_analytics: false,
+      id: 'TupcH1xvqNjsjtS8PH5rF5',
+      amount: '12.99',
+      category_id: '8dbxskvYv3k672TJCjniQx',
+      account_id: 'amex',
+    },
+  ]
+
+  private readonly demoAnalytics: AnalyticsResponse = {
+    categories: [
+      {
+        id: 'Liwwdaqt7fPJ6LKFACjpiX',
+        total: '2924.53',
+      },
+      {
+        id: 'anXz4uDvzF29jzUqX7cyPq',
+        total: '89.77',
+      },
+      {
+        id: '3v2znBBbuK6aDTAkRdfsB6',
+        total: '1234.64',
+      },
+      {
+        id: 'nmvY3NerXM3t8n3GCD3S9e',
+        total: '596.45',
+      },
+      {
+        id: 'TZuwyBFHemk95U6avZfvEf',
+        total: '518.25',
+      },
+      {
+        id: 'TdTY9ahjNKanyAvyUCmUth',
+        total: '384.38',
+      },
+      {
+        id: 'Q3enGA7mRz3zGE59edkhBB',
+        total: '131.50',
+      },
+      {
+        id: 'nK9LfGwKsFpv87XY8FYLY2',
+        total: '104.43',
+      },
+      {
+        id: '8dbxskvYv3k672TJCjniQx',
+        total: '12.99',
+      },
+    ],
+    total: '5996.94',
+  }
+
+  async fetchTransactions(month?: string, showAll?: boolean): Promise<Transaction[]> {
+    // Simulate API delay
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    if (!showAll && month) {
+      return this.demoTransactions.filter((transaction) => transaction.date.startsWith(month))
+    }
+
+    return this.demoTransactions
+  }
+
+  async fetchCategories(): Promise<Category[]> {
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    return this.demoCategories
+  }
+
+  async fetchAnalytics(month?: string, showAll?: boolean): Promise<AnalyticsResponse> {
+    await new Promise((resolve) => setTimeout(resolve, 400))
+
+    if (!showAll && month) {
+      // Calculate totals only for the specified month
+      const monthlyTransactions = this.demoTransactions.filter((t) => t.date.startsWith(month))
+
+      const categoryTotals = new Map<string | null, number>()
+      let total = 0
+
+      monthlyTransactions.forEach((transaction) => {
+        const amount = parseFloat(transaction.amount)
+        const categoryId = transaction.category_id
+
+        categoryTotals.set(categoryId, (categoryTotals.get(categoryId) || 0) + amount)
+        total += amount
+      })
+
+      return {
+        categories: Array.from(categoryTotals.entries()).map(([id, total]) => ({
+          id,
+          total: total.toFixed(2),
+        })),
+        total: total.toFixed(2),
+      }
+    }
+
+    return this.demoAnalytics
+  }
+}

--- a/client/src/services/LiveTransactionService.ts
+++ b/client/src/services/LiveTransactionService.ts
@@ -1,0 +1,28 @@
+import type { TransactionServiceInterface } from '../types/TransactionServiceInterface'
+
+export class LiveTransactionService implements TransactionServiceInterface {
+  private readonly BASE_URL = import.meta.env.VITE_API_URL
+
+  async fetchTransactions(month?: string, showAll?: boolean): Promise<Transaction[]> {
+    const params = new URLSearchParams()
+    if (month && !showAll) params.append('month', month)
+    if (showAll) params.append('all', 'true')
+
+    const response = await fetch(`${this.BASE_URL}/transactions?${params.toString()}`)
+    return response.json()
+  }
+
+  async fetchCategories(): Promise<Category[]> {
+    const response = await fetch(`${this.BASE_URL}/categories`)
+    return response.json()
+  }
+
+  async fetchAnalytics(month?: string, showAll: boolean = false): Promise<AnalyticsResponse> {
+    const url = new URL(`${this.BASE_URL}/categories/analytics`)
+    if (month && !showAll) {
+      url.searchParams.append('month', month)
+    }
+    const response = await fetch(url)
+    return await response.json()
+  }
+}

--- a/client/src/services/transactionService.ts
+++ b/client/src/services/transactionService.ts
@@ -1,0 +1,30 @@
+export class TransactionService {
+  private baseUrl: string
+
+  constructor() {
+    this.baseUrl = import.meta.env.VITE_API_URL
+  }
+
+  async fetchTransactions(month?: string, showAll: boolean = false) {
+    const url = new URL(`${this.baseUrl}/transactions`)
+    if (month && !showAll) {
+      url.searchParams.append('month', month)
+    }
+    const response = await fetch(url)
+    return await response.json()
+  }
+
+  async fetchCategories() {
+    const response = await fetch(`${this.baseUrl}/categories`)
+    return await response.json()
+  }
+
+  async fetchAnalytics(month?: string, showAll: boolean = false) {
+    const url = new URL(`${this.baseUrl}/categories/analytics`)
+    if (month && !showAll) {
+      url.searchParams.append('month', month)
+    }
+    const response = await fetch(url)
+    return await response.json()
+  }
+}

--- a/client/src/services/urlService.ts
+++ b/client/src/services/urlService.ts
@@ -1,0 +1,27 @@
+import type { Router, RouteLocationNormalizedLoaded } from 'vue-router'
+
+export class UrlService {
+  constructor(
+    private router: Router,
+    private route: RouteLocationNormalizedLoaded,
+  ) {}
+
+  updateURL(showAll: boolean, month?: string) {
+    this.router.replace({
+      query: {
+        ...(showAll ? { showAll: 'true' } : {}),
+        ...(!showAll && month ? { month } : {}),
+      },
+    })
+  }
+
+  getInitialState(): { month?: string; showAll: boolean } {
+    const monthFromUrl = this.route.query.month as string
+    const showAllFromUrl = this.route.query.showAll === 'true'
+
+    return {
+      month: monthFromUrl,
+      showAll: showAllFromUrl,
+    }
+  }
+}

--- a/client/src/types/Transaction.ts
+++ b/client/src/types/Transaction.ts
@@ -12,3 +12,9 @@ export interface Category {
   title: string
   color: string
 }
+export interface TransactionState {
+  showAllTransactions: boolean
+  currentMonth: string
+  isLoading: boolean
+  error: string | null
+}

--- a/client/src/types/Transaction.ts
+++ b/client/src/types/Transaction.ts
@@ -12,6 +12,14 @@ export interface Category {
   title: string
   color: string
 }
+
+export interface AnalyticsResponse {
+  categories: Array<{
+    id: string | null
+    total: string
+  }>
+  total: string
+}
 export interface TransactionState {
   showAllTransactions: boolean
   currentMonth: string

--- a/client/src/types/TransactionServiceInterface.ts
+++ b/client/src/types/TransactionServiceInterface.ts
@@ -1,0 +1,5 @@
+export interface TransactionServiceInterface {
+  fetchTransactions(month?: string, showAll?: boolean): Promise<Transaction[]>
+  fetchCategories(): Promise<Category[]>
+  fetchAnalytics(month?: string, showAll?: boolean): Promise<AnalyticsResponse>
+}


### PR DESCRIPTION
Changes:
- Create TransactionServiceInterface to define service contract
- Implement LiveTransactionService for production use
- Add DemoTransactionService for testing and demos
- Create Vue plugin for service provider configuration
- Update existing components to use injected service
- Add environment configuration for mode selection

How it works:
1. Create a `.env` file:
```
VITE_API_URL=your_api_url
VITE_DEMO_MODE=false/true
```
